### PR TITLE
Added 8x8 Network Utility recipe

### DIFF
--- a/8x8NetworkUtility/8x8NetworkUtility.download.recipe
+++ b/8x8NetworkUtility/8x8NetworkUtility.download.recipe
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Downloads the latest version of 8x8NetworkUtility.s</string>
+	<key>Description</key>
+	<string>Downloads the latest version of 8x8NetworkUtility.</string>
+	<key>Identifier</key>
+	<string>SPSC.download.8x8NetworkUtility</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>8x8NetworkUtility</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.zip</string>
+				<key>url</key>
+				<string>https://support.8x8.com/@api/deki/files/2507/netutil-mac_2-2-1292_2021-07-13.pkg.zip?revision=7</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: 8x8, Inc. (FC967L3QRG)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/netutil-mac_2-2-1292_2021-07-13.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+				<key>flat_pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/netutil-mac_2-2-1292_2021-07-13.pkg</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/root.pkg/Payload</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%RECIPE_CACHE_DIR%/payload/Applications/8x8NetworkUtility.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/8x8NetworkUtility/8x8NetworkUtility.pkg.recipe
+++ b/8x8NetworkUtility/8x8NetworkUtility.pkg.recipe
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Downloads the latest version of 8x8NetworkUtility and creates a package.</string>
+	<key>Description</key>
+	<string>Downloads the latest version of 8x8NetworkUtility and creates a package.</string>
+	<key>Identifier</key>
+	<string>SPSC.pkg.8x8NetworkUtility</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>8x8NetworkUtility</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>SPSC.download.8x8NetworkUtility</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>app_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/8x8NetworkUtility.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
DESKENG-2213


Package request for 8x8 Network Utility. This is used for troubleshooting 8x8 issues with end users. This should be 'available' to all workstations for Windows (priority) and Mac. 

CC: Susan Sako

----------

Hello,
Can I get some help downloading https://support.8x8.com/support-services/support/network-utility-download for myself, Nick Gunn and Patrick Sharkey, please? Customer calls are negatively impacted and are being auto-forwarded to Voicemail so we need to run this ASAP to determine root cause.

Thanks in advance!
Patrick
